### PR TITLE
Updated dates of the draft [editorial]

### DIFF
--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -8,7 +8,7 @@
 
 ## Committee Specification Draft 01 /<br>Public Review Draft 01
 
-## 24 November 2020
+## 24 February 2021
 
 #### Technical Committee:
 [OASIS Common Security Advisory Framework (CSAF) TC](https://www.oasis-open.org/committees/csaf/)
@@ -68,7 +68,7 @@ _Common Security Advisory Framework Version 2.0_. Edited by Langley Rock and Ste
 -------
 
 ## Notices
-Copyright © OASIS Open 2020. All Rights Reserved.
+Copyright © OASIS Open 2021. All Rights Reserved.
 
 All capitalized terms in the following text have the meanings assigned to them in the OASIS Intellectual Property Rights Policy (the "OASIS IPR Policy"). The full [Policy](https://www.oasis-open.org/policies-guidelines/ipr) may be found at the OASIS website.
 


### PR DESCRIPTION
After merging the latest changes from member contributions I noticed, that we still label the version as 24 November 2020 but we changed quite some parts during that revision.

So, I created a new revision by only changing the date in two places:
* Draft tagging date
* Copyright year 

Please kindly consider merging this before the February meeting. 
Thanks