### PR TITLE
Add `product_version_range` as Category enum

### DIFF
--- a/csaf/product.py
+++ b/csaf/product.py
@@ -465,6 +465,7 @@ class BranchCategory(Enum):
     product_family = 'product_family'
     product_name = 'product_name'
     product_version = 'product_version'
+    product_version_range = 'product_version_range'
     service_pack = 'service_pack'
     specification = 'specification'
     vendor = 'vendor'

--- a/csaf/schema_proxy/csaf_2_0.json
+++ b/csaf/schema_proxy/csaf_2_0.json
@@ -99,6 +99,7 @@
               "product_family",
               "product_name",
               "product_version",
+              "product_version_range",
               "service_pack",
               "specification",
               "vendor"


### PR DESCRIPTION
A branch's `category` enum can also be `product_version_range`

https://docs.oasis-open.org/csaf/csaf/v2.0/csaf_json_schema.json

```: yaml
   "category": {
            "title": "Category of the branch",
            "description": "Describes the characteristics of the labeled branch.",
            "type": "string",
            "enum": [
              "architecture",
              "host_name",
              "language",
              "legacy",
              "patch_level",
              "product_family",
              "product_name",
              "product_version",
              "product_version_range",
              "service_pack",
              "specification",
              "vendor"
            ]
```